### PR TITLE
Configure Vite server with allowed hosts

### DIFF
--- a/DevBoard.WebUI/vite.config.js
+++ b/DevBoard.WebUI/vite.config.js
@@ -4,15 +4,24 @@ import { defineConfig } from 'vite'
 import vue from '@vitejs/plugin-vue'
 import vueDevTools from 'vite-plugin-vue-devtools'
 
-// https://vite.dev/config/
 export default defineConfig({
   plugins: [
     vue(),
     vueDevTools(),
   ],
+
   resolve: {
     alias: {
       '@': fileURLToPath(new URL('./src', import.meta.url))
     },
   },
+
+  server: {
+    host: true,
+    allowedHosts: [
+      'localhost',
+      '127.0.0.1',
+      'devboard-test.duckdns.org'
+    ]
+  }
 })

--- a/DevBoard.WebUI/vite.config.js
+++ b/DevBoard.WebUI/vite.config.js
@@ -19,8 +19,7 @@ export default defineConfig({
   server: {
     host: true,
     allowedHosts: [
-      'localhost',
-      '127.0.0.1',
+      '34.171.99.177',
       'devboard-test.duckdns.org'
     ]
   }

--- a/DevBoard.WebUI/vite.config.js
+++ b/DevBoard.WebUI/vite.config.js
@@ -19,7 +19,6 @@ export default defineConfig({
   server: {
     host: true,
     allowedHosts: [
-      '34.171.99.177',
       'devboard-test.duckdns.org'
     ]
   }


### PR DESCRIPTION
Vite dev server, güvenlik nedeniyle devboard-test.duckdns.org domaininden gelen istekleri engelliyordu. Bu durum vite.config.js içinde allowed Hosts ayarı olmadığı için oluşuyordu.


<details open>
<summary><strong>🇹🇷 Türkçe</strong></summary>
<br>

## 🎯 İlgili Görev (Task)

Task Ticket Number #127 


## 📝 Açıklama

## ✅ Kontrol Listesi

- [ ] İlgili "Task Numarası" yukarıya eklendi.
- [ ] Yaptığım değişiklikler için dokümantasyon güncellendi (gerekliyse).
- [ ] Commit mesajları `CONTRIBUTING.md` dosyasındaki standartlara uygun.

</details>

---

<details>
<summary><strong>🇬🇧 English</strong></summary>
<br>

## 🎯 Related Task

Task Ticket Number #


## 📝 Description

## ✅ Checklist

- [ ] Related "Task Number" is included above.
- [ ] Documentation has been updated for my changes (if applicable).
- [ ] Commit messages follow the standards in `CONTRIBUTING.md`.

</details>